### PR TITLE
Add state tests and CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,17 @@ jobs:
       - name: Ruff Format Check
         run: |
           ruff format --check
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run tests
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ voicebot = "realtime_voicebot.app:main"
 [project.optional-dependencies]
 dev = [
   "ruff>=0.5.0",
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
 ]
 
 [tool.ruff]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from realtime_voicebot.state.conversation import ConversationState, Turn
+from realtime_voicebot.state.memory import MemoryStore
+
+
+def test_append_adds_turn_to_history():
+    state = ConversationState()
+    turn = Turn(role="user", item_id="1", text="hi")
+    state.append(turn)
+    assert state.history == [turn]
+
+
+def test_should_summarize_when_threshold_reached_and_history_long_enough():
+    state = ConversationState(latest_tokens=120)
+    for i in range(6):
+        state.append(Turn(role="user", item_id=str(i)))
+    assert state.should_summarize(threshold_tokens=100, keep_last_turns=5)
+
+
+def test_should_not_summarize_if_conditions_not_met():
+    state = ConversationState(latest_tokens=50)
+    for i in range(6):
+        state.append(Turn(role="user", item_id=str(i)))
+    assert not state.should_summarize(threshold_tokens=100, keep_last_turns=5)
+
+    state = ConversationState(latest_tokens=150)
+    for i in range(5):
+        state.append(Turn(role="user", item_id=str(i)))
+    assert not state.should_summarize(threshold_tokens=100, keep_last_turns=5)
+
+
+def test_should_not_summarize_while_summarising():
+    state = ConversationState(latest_tokens=150, summarising=True)
+    for i in range(6):
+        state.append(Turn(role="user", item_id=str(i)))
+    assert not state.should_summarize(threshold_tokens=100, keep_last_turns=5)
+
+
+def test_memory_store_set_and_get():
+    memory = MemoryStore()
+    memory.set("color", "blue")
+    assert memory.get("color") == "blue"
+    assert memory.get("missing") is None


### PR DESCRIPTION
## Summary
- add conversation state and memory store tests
- run pytest in GitHub Actions CI
- include pytest dependencies in dev extras

## Testing
- `ruff check --output-format=github` (fails: existing lint errors)
- `ruff check tests/test_state.py --output-format=github`
- `ruff format --check` (fails: existing formatting issues)
- `ruff format tests/test_state.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c588bd0d888330870a3dca6acd45ec