### PR TITLE
feat: add barge-in cancel support

### DIFF
--- a/realtime_voicebot/audio/output.py
+++ b/realtime_voicebot/audio/output.py
@@ -69,6 +69,13 @@ class AudioPlayer:
         if self._task:
             await self._task
 
+    async def flush(self) -> None:
+        """Drop pending audio and stop playback immediately."""
+        while not self._queue.empty():
+            with contextlib.suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
+        await self.stop()
+
     async def feed(self, chunk: bytes) -> None:
         with contextlib.suppress(asyncio.QueueFull):
             self._queue.put_nowait(chunk)

--- a/realtime_voicebot/handlers/core.py
+++ b/realtime_voicebot/handlers/core.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import base64
+import logging
+
+from ..audio.output import AudioPlayer
+from ..transport.client import RealtimeClient
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_response_audio_delta(
+    event: dict, client: RealtimeClient, player: AudioPlayer
+) -> None:
+    response_id = event.get("response_id")
+    if response_id is None or client.is_canceled(response_id):
+        return
+    client.active_response_id = response_id
+    audio_b64 = event.get("audio")
+    if audio_b64:
+        await player.feed(base64.b64decode(audio_b64))
+
+
+async def handle_conversation_item_created(
+    event: dict, client: RealtimeClient, player: AudioPlayer
+) -> None:
+    item = event.get("item", {})
+    if item.get("role") != "user":
+        return
+    response_id = client.active_response_id
+    if response_id:
+        await player.flush()
+        await client.cancel_active_response()
+        logger.info("barge_in", extra={"response_id": response_id, "turn_id": item.get("id")})

--- a/realtime_voicebot/transport/client.py
+++ b/realtime_voicebot/transport/client.py
@@ -72,10 +72,12 @@ class RealtimeClient:
         await self._ws.send(json.dumps(payload))
 
     async def response_cancel(self, response_id: str) -> None:
-        await self.send_json({"type": "response.cancel", "response_id": response_id})
+        # Mark as canceled locally first to immediately drop further deltas
+        # even before the server processes the cancel message.
         self._canceled.add(response_id)
         if self.active_response_id == response_id:
             self.active_response_id = None
+        await self.send_json({"type": "response.cancel", "response_id": response_id})
 
     async def cancel_active_response(self) -> None:
         if self.active_response_id:

--- a/tests/test_audio_player.py
+++ b/tests/test_audio_player.py
@@ -1,0 +1,65 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+dummy_sd = types.ModuleType("sounddevice")
+
+
+class _Stub:
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        pass
+
+    def start(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def stop(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def close(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def write(self, data: bytes) -> None:  # pragma: no cover - stub
+        pass
+
+
+dummy_sd.RawOutputStream = _Stub
+sys.modules["sounddevice"] = dummy_sd
+
+from realtime_voicebot.audio.output import AudioPlayer, PlayerConfig  # noqa: E402
+
+
+class DummyStream:
+    def __init__(self, *args, **kwargs):
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def write(self, data: bytes) -> None:  # pragma: no cover - stub
+        pass
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def close(self) -> None:  # pragma: no cover - stub
+        pass
+
+
+def test_flush_stops_player(monkeypatch):
+    import sounddevice as sd
+
+    async def run() -> None:
+        dummy = DummyStream()
+        monkeypatch.setattr(sd, "RawOutputStream", lambda *a, **k: dummy)
+        player = AudioPlayer(PlayerConfig(jitter_ms=0))
+        await player.start()
+        await player.feed(b"1234")
+        await player.flush()
+        assert player.stream is None
+        assert player._queue.empty()
+
+    asyncio.run(run())

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -1,0 +1,97 @@
+import asyncio
+import base64
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+dummy_sd = types.ModuleType("sounddevice")
+
+
+class _Stub:
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        pass
+
+    def start(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def stop(self) -> None:  # pragma: no cover - stub
+        pass
+
+    def close(self) -> None:  # pragma: no cover - stub
+        pass
+
+
+dummy_sd.RawOutputStream = _Stub
+sys.modules["sounddevice"] = dummy_sd
+sys.modules["websockets"] = types.ModuleType("websockets")
+
+from realtime_voicebot.handlers.core import (  # noqa: E402
+    handle_conversation_item_created,
+    handle_response_audio_delta,
+)
+from realtime_voicebot.transport.client import RealtimeClient  # noqa: E402
+
+
+class DummyPlayer:
+    def __init__(self) -> None:
+        self.flush_called = False
+        self.feed_chunks: list[bytes] = []
+
+    async def feed(self, chunk: bytes) -> None:
+        self.feed_chunks.append(chunk)
+
+    async def flush(self) -> None:
+        self.flush_called = True
+
+
+def test_barge_in_sends_cancel_and_stops_player(caplog: pytest.LogCaptureFixture) -> None:
+    async def run() -> None:
+        client = RealtimeClient("ws://example", {}, lambda e: None)
+        sent: list[dict] = []
+
+        async def fake_send_json(payload: dict) -> None:
+            sent.append(payload)
+
+        client.send_json = fake_send_json  # type: ignore[method-assign]
+        player = DummyPlayer()
+
+        await handle_response_audio_delta(
+            {
+                "type": "response.audio.delta",
+                "response_id": "r1",
+                "audio": base64.b64encode(b"hi").decode(),
+            },
+            client,
+            player,
+        )
+        assert client.active_response_id == "r1"
+        assert player.feed_chunks == [b"hi"]
+
+        with caplog.at_level(logging.INFO):
+            await handle_conversation_item_created(
+                {"type": "conversation.item.created", "item": {"role": "user", "id": "u1"}},
+                client,
+                player,
+            )
+
+        assert sent == [{"type": "response.cancel", "response_id": "r1"}]
+        assert player.flush_called
+        assert any(record.message == "barge_in" for record in caplog.records)
+
+        await handle_response_audio_delta(
+            {
+                "type": "response.audio.delta",
+                "response_id": "r1",
+                "audio": base64.b64encode(b"again").decode(),
+            },
+            client,
+            player,
+        )
+        assert player.feed_chunks == [b"hi"]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- enable transport to cancel active responses and ignore further deltas
- add audio player flush for barge-in and wire conversation handlers
- test audio flush and barge-in cancellation

## Testing
- `ruff check && ruff format --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5d2a466b08330a887fe783f4be914