### PR TITLE
Add fake realtime server and expand tests

### DIFF
--- a/realtime_voicebot/audio/output.py
+++ b/realtime_voicebot/audio/output.py
@@ -99,7 +99,11 @@ class AudioPlayer:
         self.stream = None
 
     async def stop(self, barge_in: bool = False) -> None:
-        # Only signal the background task if it's running.
+        """Stop playback immediately and flush any buffered audio."""
+        # Drain any queued audio so it's not played after cancellation/barge-in.
+        while not self._queue.empty():
+            with contextlib.suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
         if self._task is not None:
             await self._queue.put(None)
             await self._task

--- a/realtime_voicebot/audio/output.py
+++ b/realtime_voicebot/audio/output.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import importlib
 import logging
+import sys
 from dataclasses import dataclass
-
-import sounddevice as sd
+from typing import Any
 
 from ..metrics import (
     audio_frames_dropped_total,
@@ -32,11 +33,12 @@ class AudioPlayer:
         self.cfg = cfg
         self._queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=128)
         self._task: asyncio.Task | None = None
-        self.stream: sd.RawOutputStream | None = None
+        self.stream: Any | None = None
         self._start_lock = asyncio.Lock()
         self.log = logging.getLogger(__name__)
 
     async def start(self) -> None:
+        sd = sys.modules.get("sounddevice") or importlib.import_module("sounddevice")
         self.stream = sd.RawOutputStream(
             samplerate=self.cfg.sample_rate_hz,
             dtype="int16",

--- a/realtime_voicebot/state/conversation.py
+++ b/realtime_voicebot/state/conversation.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from ..summarization.base import Summarizer
+
 Role = Literal["user", "assistant", "system"]
 
 
@@ -30,3 +32,26 @@ class ConversationState:
             and len(self.history) > keep_last_turns
             and not self.summarising
         )
+
+    async def summarize_and_prune(
+        self,
+        summarizer: Summarizer,
+        keep_last_turns: int,
+        language: str | None = None,
+    ) -> None:
+        """Summarize conversation and keep only the last ``keep_last_turns``.
+
+        The produced summary is inserted as a ``system`` turn at the beginning
+        of the history. ``summary_count`` is incremented each time this method is
+        called.
+        """
+        self.summarising = True
+        try:
+            summary = await summarizer.summarize(self.history, language)
+        finally:
+            self.summarising = False
+
+        self.summary_count += 1
+        summary_turn = Turn(role="system", item_id=f"summary-{self.summary_count}", text=summary)
+        self.history = [summary_turn] + self.history[-keep_last_turns:]
+        self.latest_tokens = 0

--- a/realtime_voicebot/summarization/base.py
+++ b/realtime_voicebot/summarization/base.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from ..state.conversation import Turn
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..state.conversation import Turn
 
 
 class Summarizer(Protocol):

--- a/tests/fakes/fake_realtime_server.py
+++ b/tests/fakes/fake_realtime_server.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterable
+from contextlib import asynccontextmanager
+
+
+class _FakeConnection:
+    def __init__(self, events: list[dict], received: list[dict]):
+        self._events = asyncio.Queue[str | None]()
+        for ev in events:
+            self._events.put_nowait(json.dumps(ev))
+        self._events.put_nowait(None)
+        self._received = received
+
+    async def __aenter__(self) -> _FakeConnection:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup needed
+        return None
+
+    def __aiter__(self) -> _FakeConnection:
+        return self
+
+    async def __anext__(self) -> str:
+        msg = await self._events.get()
+        if msg is None:
+            raise StopAsyncIteration
+        return msg
+
+    async def send(self, msg: str) -> None:
+        self._received.append(json.loads(msg))
+
+    async def close(self) -> None:  # pragma: no cover - no-op for compatibility
+        return None
+
+
+class FakeRealtimeServer:
+    """In-memory stand-in for the OpenAI Realtime server."""
+
+    def __init__(self, events: Iterable[dict]):
+        self.events = list(events)
+        self.received: list[dict] = []
+
+    @asynccontextmanager
+    async def connect(self, *args, **kwargs):  # pragma: no cover - simple context
+        conn = _FakeConnection(self.events, self.received)
+        yield conn

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,62 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class FakeStream:
+    def __init__(self, *args, **kwargs):
+        self.written = []
+
+    def start(self):
+        pass
+
+    def write(self, data: bytes):
+        self.written.append(data)
+
+    def stop(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_audio_player_jitter_and_flush(monkeypatch):
+    async def main():
+        # Provide fake sounddevice module before importing player
+        import types
+
+        fake_sd = types.SimpleNamespace(RawOutputStream=FakeStream)
+        monkeypatch.setitem(sys.modules, "sounddevice", fake_sd)
+
+        from realtime_voicebot.audio.output import AudioPlayer, PlayerConfig
+
+        cfg = PlayerConfig(sample_rate_hz=1000, jitter_ms=10)
+        player = AudioPlayer(cfg)
+        await player.start()
+
+        stream = player.stream  # type: ignore[assignment]
+
+        await player.feed(b"a" * 10)  # below jitter
+        await asyncio.sleep(0)
+        assert stream.written == []
+
+        await player.feed(b"a" * 10)  # reach jitter (20 bytes)
+        await asyncio.sleep(0)
+        assert len(stream.written) == 1 and len(stream.written[0]) == 20
+
+        await player.feed(b"b" * 5)
+        for _ in range(5):
+            if len(stream.written) >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert len(stream.written) == 2 and len(stream.written[1]) == 5
+
+        await player.feed(b"c" * 5)
+        await player.stop()
+        await asyncio.sleep(0)
+        # last chunk should be flushed, no new writes after stop
+        assert len(stream.written) == 2
+
+    asyncio.run(main())

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,0 +1,28 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from realtime_voicebot.state.conversation import ConversationState, Turn
+
+
+def test_summarize_and_prune_inserts_summary_and_keeps_last_turns():
+    async def main():
+        state = ConversationState(latest_tokens=200)
+        for i in range(5):
+            state.append(Turn(role="user", item_id=str(i), text=f"t{i}"))
+
+        class DummySummarizer:
+            async def summarize(self, turns, language=None):
+                return "Summary: dummy"
+
+        await state.summarize_and_prune(DummySummarizer(), keep_last_turns=2)
+
+        assert len(state.history) == 3
+        assert state.history[0].role == "system"
+        assert state.history[0].text.startswith("Summary:")
+        assert [t.item_id for t in state.history[1:]] == ["3", "4"]
+        assert state.summary_count == 1
+
+    asyncio.run(main())

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,54 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from realtime_voicebot.handlers.dispatcher import Dispatcher
+from tests.fakes.fake_realtime_server import FakeRealtimeServer
+
+
+def test_transport_event_dispatch_and_barge_in_response_cancel(monkeypatch):
+    async def main():
+        events = [
+            {"type": "session.created"},
+            {"type": "response.audio.delta", "audio": ""},
+            {"type": "conversation.item.created", "item": {"role": "user"}},
+            {"type": "response.done"},
+        ]
+
+        server = FakeRealtimeServer(events)
+
+        import types
+
+        fake_ws = types.SimpleNamespace(connect=server.connect, WebSocketClientProtocol=object)
+        monkeypatch.setitem(sys.modules, "websockets", fake_ws)
+
+        from realtime_voicebot.transport.client import RealtimeClient
+
+        received = []
+        dispatcher = Dispatcher()
+
+        async def record(event):
+            received.append(event["type"])
+
+        for etype in ["session.created", "response.audio.delta", "response.done"]:
+            dispatcher.register(etype, record)
+
+        async def on_item_created(event):
+            received.append(event["type"])
+            if event["item"]["role"] == "user":
+                await client.send_json({"type": "response.cancel"})
+
+        dispatcher.register("conversation.item.created", on_item_created)
+
+        client = RealtimeClient("ws://fake", {}, dispatcher.dispatch)
+        task = asyncio.create_task(client.connect())
+        await asyncio.sleep(0.1)
+        await client.close()
+        await task
+
+        assert received == [e["type"] for e in events]
+        assert {msg["type"] for msg in server.received} == {"response.cancel"}
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add in-memory fake Realtime server for transport tests
- flush AudioPlayer buffers on stop to prevent residual playback
- implement conversation summarization and pruning helper
- exercise new behavior with transport, audio jitter, and summarization tests

## Testing
- `ruff check .`
- `pytest tests/test_audio.py tests/test_summarization.py tests/test_transport.py tests/test_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d2ef8a6c8330a1e60151f2931fdc