### PR TITLE
feat: add language-aware summarization policy

### DIFF
--- a/realtime_voicebot/state/conversation.py
+++ b/realtime_voicebot/state/conversation.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Literal
 
 from ..summarization.base import Summarizer
+from ..transport.client import RealtimeClient
 
 Role = Literal["user", "assistant", "system"]
 
@@ -13,6 +15,38 @@ class Turn:
     role: Role
     item_id: str
     text: str | None = None
+
+
+def _detect_language(texts: list[str]) -> str:
+    """Very small heuristic language detector.
+
+    This intentionally avoids heavy dependencies. It looks for common Spanish
+    or French words in the recent turns and falls back to English.
+    """
+    sample = " ".join(t.lower() for t in texts)
+    if re.search(r"\b(hola|gracias|por favor|adios)\b", sample):
+        return "es"
+    if re.search(r"\b(bonjour|merci|s'il|au revoir)\b", sample):
+        return "fr"
+    return "en"
+
+
+@dataclass
+class SummaryPolicy:
+    threshold_tokens: int
+    keep_last_turns: int
+    language_policy: Literal["auto", "en", "force"] = "auto"
+
+    def should_summarize(self, state: ConversationState) -> bool:
+        return state.should_summarize(self.threshold_tokens, self.keep_last_turns)
+
+    def determine_language(self, turns: list[Turn]) -> str | None:
+        if self.language_policy == "en":
+            return "en"
+        if self.language_policy in {"auto", "force"}:
+            texts = [t.text or "" for t in turns if t.text]
+            return _detect_language(texts) if texts else "en"
+        return None
 
 
 @dataclass
@@ -38,6 +72,7 @@ class ConversationState:
         summarizer: Summarizer,
         keep_last_turns: int,
         language: str | None = None,
+        client: RealtimeClient | None = None,
     ) -> None:
         """Summarize conversation and keep only the last ``keep_last_turns``.
 
@@ -51,7 +86,28 @@ class ConversationState:
         finally:
             self.summarising = False
 
+        old_turns = self.history[:-keep_last_turns]
+        recent = self.history[-keep_last_turns:]
         self.summary_count += 1
-        summary_turn = Turn(role="system", item_id=f"summary-{self.summary_count}", text=summary)
-        self.history = [summary_turn] + self.history[-keep_last_turns:]
+        summary_id = f"summary-{self.summary_count}"
+        summary_turn = Turn(role="system", item_id=summary_id, text=summary)
+        self.history = [summary_turn] + recent
         self.latest_tokens = 0
+
+        if client:
+            await client.send_json(
+                {
+                    "type": "conversation.item.create",
+                    "previous_item_id": "root",
+                    "item": {
+                        "id": summary_id,
+                        "type": "message",
+                        "role": "system",
+                        "content": [{"type": "input_text", "text": summary}],
+                    },
+                }
+            )
+            for turn in old_turns:
+                await client.send_json(
+                    {"type": "conversation.item.delete", "item_id": turn.item_id}
+                )

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -4,7 +4,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from realtime_voicebot.state.conversation import ConversationState, Turn
+from realtime_voicebot.handlers.core import handle_response_done
+from realtime_voicebot.handlers.dispatcher import Dispatcher
+from realtime_voicebot.state.conversation import (
+    ConversationState,
+    SummaryPolicy,
+    Turn,
+)
+from realtime_voicebot.summarization.openai_impl import OpenAISummarizer
+from realtime_voicebot.transport.client import RealtimeClient
+from tests.fakes.fake_realtime_server import FakeRealtimeServer
 
 
 def test_summarize_and_prune_inserts_summary_and_keeps_last_turns():
@@ -24,5 +33,77 @@ def test_summarize_and_prune_inserts_summary_and_keeps_last_turns():
         assert state.history[0].text.startswith("Summary:")
         assert [t.item_id for t in state.history[1:]] == ["3", "4"]
         assert state.summary_count == 1
+
+    asyncio.run(main())
+
+
+def test_openai_summarizer_returns_non_empty_string():
+    async def main():
+        summarizer = OpenAISummarizer()
+        text = await summarizer.summarize([Turn(role="user", item_id="1", text="hello")])
+        assert text.strip() != ""
+
+    asyncio.run(main())
+
+
+def test_e2e_summary_added_and_prunes_history(monkeypatch):
+    async def main():
+        events = [
+            {
+                "type": "response.done",
+                "response": {
+                    "output": [
+                        {
+                            "id": "a2",
+                            "role": "assistant",
+                            "content": [{"transcript": "resp"}],
+                        }
+                    ],
+                    "usage": {"total_tokens": 5000},
+                },
+            }
+        ]
+
+        server = FakeRealtimeServer(events)
+
+        import types
+
+        fake_ws = types.SimpleNamespace(connect=server.connect, WebSocketClientProtocol=object)
+        monkeypatch.setitem(sys.modules, "websockets", fake_ws)
+
+        state = ConversationState()
+        state.append(Turn(role="user", item_id="u1", text="hola"))
+        state.append(Turn(role="assistant", item_id="a1", text="hola"))
+        state.append(Turn(role="user", item_id="u2", text="gracias"))
+
+        summarizer = OpenAISummarizer()
+        policy = SummaryPolicy(threshold_tokens=1000, keep_last_turns=2, language_policy="auto")
+
+        dispatcher = Dispatcher()
+
+        client = RealtimeClient("ws://fake", {}, dispatcher.dispatch)
+        dispatcher.register(
+            "response.done",
+            lambda ev: handle_response_done(ev, client, state, summarizer, policy),
+        )
+
+        task = asyncio.create_task(client.connect())
+        await asyncio.sleep(0.1)
+        await client.close()
+        await task
+
+        # Summary inserted and history pruned
+        assert state.history[0].role == "system"
+        assert [t.item_id for t in state.history[1:]] == ["u2", "a2"]
+
+        # Server received summary creation and deletes of old items
+        types_sent = {msg["type"] for msg in server.received}
+        assert "conversation.item.create" in types_sent
+        delete_ids = {
+            msg.get("item_id")
+            for msg in server.received
+            if msg["type"] == "conversation.item.delete"
+        }
+        assert {"u1", "a1"} == delete_ids
 
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add SummaryPolicy with heuristic language detection and server pruning
- implement response.done handler that triggers summarization
- provide OpenAI summarizer stub and tests including fake server e2e

## Testing
- `python -m ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ed2d0eb08330b11596195b8189ec