### PR TITLE
Add queue depth metrics and dropped frame logging

### DIFF
--- a/realtime_voicebot/audio/output.py
+++ b/realtime_voicebot/audio/output.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from ..metrics import (
     audio_frames_dropped_total,
+    audio_output_queue_depth,
     first_delta_to_playback_ms,
 )
 
@@ -56,6 +57,7 @@ class AudioPlayer:
                 "latency_ms": first_delta_to_playback_ms.last_ms,
                 "tokens_total": None,
                 "dropped_frames": audio_frames_dropped_total.value,
+                "queue_depth": audio_output_queue_depth.value,
             },
         )
 
@@ -87,6 +89,7 @@ class AudioPlayer:
                 "latency_ms": first_delta_to_playback_ms.last_ms,
                 "tokens_total": None,
                 "dropped_frames": audio_frames_dropped_total.value,
+                "queue_depth": audio_output_queue_depth.value,
             },
         )
 
@@ -120,6 +123,7 @@ class AudioPlayer:
                 "latency_ms": None,
                 "tokens_total": None,
                 "dropped_frames": audio_frames_dropped_total.value,
+                "queue_depth": audio_output_queue_depth.value,
             },
         )
 
@@ -141,3 +145,28 @@ class AudioPlayer:
             self._queue.put_nowait(chunk)
         except asyncio.QueueFull:
             audio_frames_dropped_total.inc()
+            self.log.warning(
+                "audio_output_queue_full",
+                extra={
+                    "event_type": "audio_output_queue_full",
+                    "turn_id": None,
+                    "response_id": None,
+                    "latency_ms": None,
+                    "tokens_total": None,
+                    "dropped_frames": audio_frames_dropped_total.value,
+                    "queue_depth": self._queue.qsize(),
+                },
+            )
+        audio_output_queue_depth.set(self._queue.qsize())
+        self.log.debug(
+            "audio_output_queue_depth",
+            extra={
+                "event_type": "audio_output_queue_depth",
+                "turn_id": None,
+                "response_id": None,
+                "latency_ms": None,
+                "tokens_total": None,
+                "dropped_frames": audio_frames_dropped_total.value,
+                "queue_depth": audio_output_queue_depth.value,
+            },
+        )

--- a/realtime_voicebot/metrics.py
+++ b/realtime_voicebot/metrics.py
@@ -12,6 +12,14 @@ class Counter:
         self.value += n
 
 
+class Gauge:
+    def __init__(self) -> None:
+        self.value = 0
+
+    def set(self, v: int) -> None:
+        self.value = v
+
+
 class Timer:
     def __init__(self) -> None:
         self.last_ms: float | None = None
@@ -41,3 +49,5 @@ reconnections_total = Counter()
 audio_frames_dropped_total = Counter()
 eos_to_first_delta_ms = Timer()
 first_delta_to_playback_ms = Timer()
+audio_input_queue_depth = Gauge()
+audio_output_queue_depth = Gauge()

--- a/realtime_voicebot/transport/client.py
+++ b/realtime_voicebot/transport/client.py
@@ -13,6 +13,7 @@ from ..errors import ErrorCategory
 from ..metrics import (
     audio_frames_dropped_total,
     eos_to_first_delta_ms,
+    audio_input_queue_depth,
     reconnections_total,
 )
 from .events import EventHandler
@@ -208,6 +209,31 @@ class RealtimeClient:
             self._audio_q.put_nowait(chunk)
         except asyncio.QueueFull:
             audio_frames_dropped_total.inc()
+            logging.getLogger(__name__).warning(
+                "audio_input_queue_full",
+                extra={
+                    "event_type": "audio_input_queue_full",
+                    "turn_id": None,
+                    "response_id": None,
+                    "latency_ms": None,
+                    "tokens_total": None,
+                    "dropped_frames": audio_frames_dropped_total.value,
+                    "queue_depth": self._audio_q.qsize(),
+                },
+            )
+        audio_input_queue_depth.set(self._audio_q.qsize())
+        logging.getLogger(__name__).debug(
+            "audio_input_queue_depth",
+            extra={
+                "event_type": "audio_input_queue_depth",
+                "turn_id": None,
+                "response_id": None,
+                "latency_ms": None,
+                "tokens_total": None,
+                "dropped_frames": audio_frames_dropped_total.value,
+                "queue_depth": audio_input_queue_depth.value,
+            },
+        )
 
     async def send_json(self, payload: dict) -> None:
         if not self._ws:


### PR DESCRIPTION
## Summary
- track audio input/output queue depths via new Gauge metrics
- log queue depth and dropped frames for AudioPlayer and RealtimeClient
- test AudioPlayer feed dropping when queue is full

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pytest tests/test_audio_player.py::test_feed_queue_full_increments_metric -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7690e60988330848e1c21fbe74c05