### PR TITLE
feat: add Azure OpenAI provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# OpenAI provider (default)
+PROVIDER=openai
+OPENAI_API_KEY=sk-your-openai-key
+# Optional: OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Azure OpenAI provider
+#PROVIDER=azure
+#AZURE_OPENAI_API_KEY=your-azure-key
+#AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+#AZURE_OPENAI_API_VERSION=2024-07-01-preview
+#AZURE_OPENAI_DEPLOYMENT=realtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ Use these steps as an incremental, verifiable path. You do not need to finish al
   - `voicebot devices list`
 - Testing: `pytest -q` (add `pytest-asyncio` for async tests).
 - Linting/typing: ruff + mypy (recommend pre-commit hooks).
+- Run `pre-commit run --files <file1> <file2>` on changed files before committing.
 
 ## Pitfalls & Tips
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,32 @@ This repo is intended to serve as a more robust example of a long conversation a
 
 The original script that was converted can be found here: `original/realtime_agent_cli.py`
 
+## Configuration
+
+Set environment variables or create a `.env` file. For OpenAI:
+
+```bash
+PROVIDER=openai
+OPENAI_API_KEY=sk-...
+```
+
+For Azure OpenAI:
+
+```bash
+PROVIDER=azure
+AZURE_OPENAI_API_KEY=your-azure-key
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+AZURE_OPENAI_API_VERSION=2024-07-01-preview
+AZURE_OPENAI_DEPLOYMENT=realtime
+```
+
+CLI flags can override these values, e.g.:
+
+```bash
+voicebot run --provider azure --endpoint https://your-resource.openai.azure.com \
+  --deployment realtime --api-version 2024-07-01-preview
+```
+
 ## Development
 
 Create a virtual environment with Python 3.11 or newer and install the development

--- a/realtime_voicebot/cli.py
+++ b/realtime_voicebot/cli.py
@@ -31,12 +31,8 @@ def run(
     ),
     provider: str | None = typer.Option(None, help="API provider"),
     endpoint: str | None = typer.Option(None, help="Azure OpenAI endpoint"),
-    deployment: str | None = typer.Option(
-        None, help="Azure OpenAI deployment name"
-    ),
-    api_version: str | None = typer.Option(
-        None, help="Azure OpenAI API version"
-    ),
+    deployment: str | None = typer.Option(None, help="Azure OpenAI deployment name"),
+    api_version: str | None = typer.Option(None, help="Azure OpenAI API version"),
     verbose: bool = typer.Option(False, help="Print effective settings"),
 ) -> None:
     """Run the voicebot orchestrator."""

--- a/realtime_voicebot/cli.py
+++ b/realtime_voicebot/cli.py
@@ -29,6 +29,14 @@ def run(
     summary_threshold: int | None = typer.Option(
         None, help="Token threshold to trigger summarization"
     ),
+    provider: str | None = typer.Option(None, help="API provider"),
+    endpoint: str | None = typer.Option(None, help="Azure OpenAI endpoint"),
+    deployment: str | None = typer.Option(
+        None, help="Azure OpenAI deployment name"
+    ),
+    api_version: str | None = typer.Option(
+        None, help="Azure OpenAI API version"
+    ),
     verbose: bool = typer.Option(False, help="Print effective settings"),
 ) -> None:
     """Run the voicebot orchestrator."""
@@ -43,6 +51,14 @@ def run(
         overrides["output_device_id"] = output_device
     if summary_threshold is not None:
         overrides["summary_trigger_tokens"] = summary_threshold
+    if provider is not None:
+        overrides["provider"] = provider
+    if endpoint is not None:
+        overrides["azure_openai_endpoint"] = endpoint
+    if deployment is not None:
+        overrides["azure_openai_deployment"] = deployment
+    if api_version is not None:
+        overrides["azure_openai_api_version"] = api_version
     # Merge CLI overrides into the loaded settings instance to preserve types
     # and keep mypy satisfied about update semantics.
     settings = get_settings().model_copy(update=overrides)

--- a/realtime_voicebot/config.py
+++ b/realtime_voicebot/config.py
@@ -14,11 +14,20 @@ class Settings(BaseSettings):
     overridden via CLI flags by the application entrypoint.
     """
 
+    # Provider selection
+    provider: Literal["openai", "azure"] = "openai"
+
     # OpenAI / API configuration
     # Note: allow empty by default so CLI/tests can run without a key.
     # Connection layers should validate presence when contacting the API.
     openai_api_key: str = ""
     openai_base_url: str | None = None
+
+    # Azure OpenAI configuration
+    azure_openai_api_key: str = ""
+    azure_openai_endpoint: str | None = None
+    azure_openai_api_version: str = "2024-07-01-preview"
+    azure_openai_deployment: str = "realtime"
 
     # Models & voice
     realtime_model: str = "gpt-4o-realtime-preview"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,7 @@ def test_run_azure_overrides(monkeypatch):
     assert settings.azure_openai_deployment == "mydeploy"
     assert settings.azure_openai_api_version == "2024-06-01"
 
+
 def test_devices_list(monkeypatch):
     fake_sd = types.SimpleNamespace(
         query_devices=lambda: [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,35 @@ def test_run_overrides(monkeypatch):
     assert "foo" in result.stdout
 
 
+def test_run_azure_overrides(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_run(settings):
+        captured["settings"] = settings
+
+    monkeypatch.setattr("realtime_voicebot.app.run", fake_run)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "run",
+            "--provider",
+            "azure",
+            "--endpoint",
+            "https://example.openai.azure.com",
+            "--deployment",
+            "mydeploy",
+            "--api-version",
+            "2024-06-01",
+        ],
+    )
+    assert result.exit_code == 0
+    settings = captured["settings"]
+    assert settings.provider == "azure"
+    assert settings.azure_openai_endpoint == "https://example.openai.azure.com"
+    assert settings.azure_openai_deployment == "mydeploy"
+    assert settings.azure_openai_api_version == "2024-06-01"
+
 def test_devices_list(monkeypatch):
     fake_sd = types.SimpleNamespace(
         query_devices=lambda: [

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+from realtime_voicebot.config import Settings
+from realtime_voicebot.transport.client import RealtimeClient, build_ws_url_headers
+from tests.fakes.fake_realtime_server import FakeRealtimeServer
+
+
+def _fake_ws(monkeypatch, server):
+    fake_ws = types.SimpleNamespace(connect=server.connect, WebSocketClientProtocol=object)
+    monkeypatch.setitem(sys.modules, "websockets", fake_ws)
+
+
+def test_build_openai_ws(monkeypatch):
+    settings = Settings(openai_api_key="sk")
+    url, headers = build_ws_url_headers(settings)
+    assert url == "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview"
+    assert headers == {
+        "Authorization": "Bearer sk",
+        "OpenAI-Beta": "realtime=v1",
+    }
+    server = FakeRealtimeServer([{"type": "session.created"}])
+    _fake_ws(monkeypatch, server)
+
+    async def on_event(ev):
+        await client.close()
+
+    client = RealtimeClient(url, headers, on_event, session_config={"voice": "test"})
+    asyncio.run(client.connect())
+    assert server.received == [{"type": "session.update", "session": {"voice": "test"}}]
+
+
+def test_build_azure_ws(monkeypatch):
+    settings = Settings(
+        provider="azure",
+        azure_openai_api_key="key",
+        azure_openai_endpoint="https://example.openai.azure.com",
+        azure_openai_api_version="2024-06-01",
+        azure_openai_deployment="realtime",
+    )
+    url, headers = build_ws_url_headers(settings)
+    assert (
+        url
+        == "wss://example.openai.azure.com/openai/realtime?api-version=2024-06-01&deployment=realtime"
+    )
+    assert headers == {"api-key": "key"}
+    server = FakeRealtimeServer([{"type": "session.created"}])
+    _fake_ws(monkeypatch, server)
+
+    async def on_event(ev):
+        await client.close()
+
+    client = RealtimeClient(url, headers, on_event, session_config={"voice": "test"})
+    asyncio.run(client.connect())
+    assert server.received == [{"type": "session.update", "session": {"voice": "test"}}]


### PR DESCRIPTION
## Summary
- add provider settings for OpenAI and Azure
- construct provider-specific websocket URLs and headers
- expose provider and Azure flags in CLI
- document configuration for both providers and add `.env` example
- cover transport setup for each provider in tests

## Testing
- `pre-commit run --files realtime_voicebot/config.py realtime_voicebot/transport/client.py realtime_voicebot/cli.py README.md .env.example tests/test_cli.py tests/test_provider.py` *(command failed: pre-commit not found)*
- `mypy realtime_voicebot`
- `pytest -q` *(errors: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c8209fbe64833089beadc307745981