### PR TITLE
Implement conversation transcript backfill and summary deferral

### DIFF
--- a/realtime_voicebot/app.py
+++ b/realtime_voicebot/app.py
@@ -18,6 +18,7 @@ async def run(settings: Settings | None = None) -> None:
     from .audio.output import AudioPlayer, PlayerConfig
     from .handlers.core import (
         handle_conversation_item_created,
+        handle_conversation_item_retrieved,
         handle_response_audio_delta,
         handle_response_created,
         handle_response_done,
@@ -81,6 +82,12 @@ async def run(settings: Settings | None = None) -> None:
         lambda ev: handle_conversation_item_created(ev, client, player),
     )
     dispatcher.on(
+        "conversation.item.retrieved",
+        lambda ev: handle_conversation_item_retrieved(
+            ev, client, state, summarizer, policy
+        ),
+    )
+    dispatcher.on(
         "response.done",
         lambda ev: handle_response_done(ev, client, state, summarizer, policy),
     )
@@ -89,9 +96,6 @@ async def run(settings: Settings | None = None) -> None:
         lambda ev: handle_tool_call(ev, client, registry),
     )
     dispatcher.on("response.error", lambda ev: handle_response_error(ev, client))
-
-    # Placeholder for future transcript backfill support.
-    dispatcher.on("conversation.item.retrieved", lambda _ev: asyncio.sleep(0))
 
     # Mic input queue ---------------------------------------------------------
     audio_q: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=32)

--- a/realtime_voicebot/app.py
+++ b/realtime_voicebot/app.py
@@ -79,13 +79,11 @@ async def run(settings: Settings | None = None) -> None:
     )
     dispatcher.on(
         "conversation.item.created",
-        lambda ev: handle_conversation_item_created(ev, client, player),
+        lambda ev: handle_conversation_item_created(ev, client, player, state),
     )
     dispatcher.on(
         "conversation.item.retrieved",
-        lambda ev: handle_conversation_item_retrieved(
-            ev, client, state, summarizer, policy
-        ),
+        lambda ev: handle_conversation_item_retrieved(ev, client, state, summarizer, policy),
     )
     dispatcher.on(
         "response.done",

--- a/realtime_voicebot/config.py
+++ b/realtime_voicebot/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 try:
     from pydantic import PositiveInt
@@ -9,23 +9,34 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - lightweight fallback for tests
     import json
 
-    PositiveInt = int
+    if TYPE_CHECKING:  # pragma: no cover - satisfy type checkers
+        from pydantic import PositiveInt  # type: ignore[import]
+        from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore[import]
+    else:
 
-    class BaseSettings:  # pragma: no cover - trivial shim
-        def __init__(self, **kwargs):
-            for key, value in kwargs.items():
-                setattr(self, key, value)
+        class PositiveInt(int):  # type: ignore[no-redef]
+            """Runtime shim that mimics ``pydantic.PositiveInt``."""
 
-        def model_dump(self) -> dict:
-            annotations = getattr(self.__class__, "__annotations__", {})
-            return {name: getattr(self, name) for name in annotations}
+            def __new__(cls, value: int) -> "PositiveInt":
+                if value <= 0:
+                    raise ValueError("PositiveInt must be positive")
+                return int.__new__(cls, value)
 
-        def model_dump_json(self, indent: int | None = None) -> str:
-            return json.dumps(self.model_dump(), indent=indent)
+        class BaseSettings:  # pragma: no cover - trivial shim
+            def __init__(self, **kwargs):
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
 
-    class SettingsConfigDict(dict):  # pragma: no cover - trivial shim
-        def __init__(self, **kwargs) -> None:
-            super().__init__(**kwargs)
+            def model_dump(self) -> dict:
+                annotations = getattr(self.__class__, "__annotations__", {})
+                return {name: getattr(self, name) for name in annotations}
+
+            def model_dump_json(self, indent: int | None = None) -> str:
+                return json.dumps(self.model_dump(), indent=indent)
+
+        class SettingsConfigDict(dict):  # pragma: no cover - trivial shim
+            def __init__(self, **kwargs) -> None:
+                super().__init__(**kwargs)
 
 
 class Settings(BaseSettings):

--- a/realtime_voicebot/config.py
+++ b/realtime_voicebot/config.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - lightweight fallback for tests
         class PositiveInt(int):  # type: ignore[no-redef]
             """Runtime shim that mimics ``pydantic.PositiveInt``."""
 
-            def __new__(cls, value: int) -> "PositiveInt":
+            def __new__(cls, value: int) -> PositiveInt:
                 if value <= 0:
                     raise ValueError("PositiveInt must be positive")
                 return int.__new__(cls, value)

--- a/realtime_voicebot/handlers/core.py
+++ b/realtime_voicebot/handlers/core.py
@@ -84,7 +84,7 @@ async def handle_response_done(
             state.append(Turn(role="assistant", item_id=item.get("id", ""), text=txt))
 
     usage = resp.get("usage", {})
-    state.latest_tokens = usage.get("total_tokens", 0)
+    state.record_usage(usage.get("total_tokens"))
 
     if policy.should_summarize(state):
         language = policy.determine_language(state.history)

--- a/realtime_voicebot/handlers/core.py
+++ b/realtime_voicebot/handlers/core.py
@@ -4,7 +4,7 @@ import base64
 import logging
 
 from ..audio.output import AudioPlayer
-from ..state.conversation import ConversationState, SummaryPolicy, Turn, Role
+from ..state.conversation import ConversationState, Role, SummaryPolicy, Turn
 from ..summarization.base import Summarizer
 from ..transport.client import RealtimeClient
 

--- a/realtime_voicebot/handlers/core.py
+++ b/realtime_voicebot/handlers/core.py
@@ -4,7 +4,7 @@ import base64
 import logging
 
 from ..audio.output import AudioPlayer
-from ..state.conversation import ConversationState, SummaryPolicy, Turn
+from ..state.conversation import ConversationState, SummaryPolicy, Turn, Role
 from ..summarization.base import Summarizer
 from ..transport.client import RealtimeClient
 
@@ -136,7 +136,8 @@ async def handle_conversation_item_retrieved(
             break
 
     if not updated:
-        role = item.get("role") or "user"
+        role_value = item.get("role")
+        role: Role = role_value if role_value in {"user", "assistant", "system"} else "user"
         state.append(Turn(role=role, item_id=item_id, text=transcript))
         updated = True
 

--- a/realtime_voicebot/state/conversation.py
+++ b/realtime_voicebot/state/conversation.py
@@ -90,13 +90,13 @@ class ConversationState:
         of the history. ``summary_count`` is incremented each time this method is
         called.
         """
+
         # Defer summarization/pruning if any of the turns that would be pruned
         # are still missing transcripts. This avoids deleting server-side items
         # that have not yet been backfilled by conversation.item.retrieved.
         def _has_pending(turns: list[Turn]) -> bool:
             return any(
-                t.role != "system" and (t.text is None or not str(t.text).strip())
-                for t in turns
+                t.role != "system" and (t.text is None or not str(t.text).strip()) for t in turns
             )
 
         old_turns = self.history[:-keep_last_turns]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -62,3 +62,16 @@ def test_summary_policy_language_detection_and_trigger():
 
     policy_en = SummaryPolicy(threshold_tokens=100, keep_last_turns=2, language_policy="en")
     assert policy_en.determine_language(state.history) == "en"
+
+
+def test_record_usage_retains_peak_tokens_until_summary():
+    state = ConversationState()
+    for i in range(6):
+        state.append(Turn(role="user", item_id=str(i), text=f"t{i}"))
+
+    state.record_usage(120)
+    state.record_usage(5)
+
+    assert state.latest_tokens == 5
+    assert state.pending_summary_tokens == 120
+    assert state.should_summarize(threshold_tokens=100, keep_last_turns=5)

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from realtime_voicebot.handlers.core import handle_response_done
+from realtime_voicebot.handlers.core import (
+    handle_conversation_item_retrieved,
+    handle_response_done,
+)
 from realtime_voicebot.state.conversation import (
     ConversationState,
     SummaryPolicy,
@@ -37,6 +40,125 @@ def test_summarize_and_prune_inserts_summary_and_keeps_last_turns():
     asyncio.run(main())
 
 
+def test_conversation_item_retrieved_backfills_text():
+    async def main():
+        state = ConversationState()
+        state.append(Turn(role="user", item_id="u1"))
+
+        class DummySummarizer:
+            async def summarize(self, turns, language=None):  # pragma: no cover - unused
+                raise AssertionError("summarize should not be called")
+
+        policy = SummaryPolicy(threshold_tokens=1000, keep_last_turns=2)
+        await handle_conversation_item_retrieved(
+            {
+                "type": "conversation.item.retrieved",
+                "item": {
+                    "id": "u1",
+                    "role": "user",
+                    "content": [{"type": "input_text", "transcript": "hola"}],
+                },
+            },
+            None,
+            state,
+            DummySummarizer(),
+            policy,
+        )
+
+        assert state.history[0].text == "hola"
+
+    asyncio.run(main())
+
+
+def test_summary_defers_until_transcript_backfilled():
+    async def main():
+        state = ConversationState()
+        state.append(Turn(role="user", item_id="u1"))
+        state.append(Turn(role="assistant", item_id="a1", text="ack"))
+        state.append(Turn(role="user", item_id="u2", text="next"))
+
+        class DummySummarizer:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def summarize(self, turns, language=None):
+                self.calls += 1
+                return "Summary stub"
+
+        summarizer = DummySummarizer()
+        policy = SummaryPolicy(threshold_tokens=10, keep_last_turns=2)
+
+        class DummyClient:
+            def __init__(self) -> None:
+                self.active_response_id: str | None = None
+                self.sent: list[dict] = []
+
+            def clear_canceled(self, response_id: str | None) -> None:  # pragma: no cover - trivial
+                return None
+
+            async def send_json(self, payload: dict) -> None:
+                self.sent.append(payload)
+
+        client = DummyClient()
+
+        await handle_response_done(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "r1",
+                    "output": [
+                        {
+                            "id": "a2",
+                            "role": "assistant",
+                            "content": [{"transcript": "resp"}],
+                        }
+                    ],
+                    "usage": {"total_tokens": 50},
+                },
+            },
+            client,
+            state,
+            summarizer,
+            policy,
+        )
+
+        assert summarizer.calls == 0
+        assert state.summary_count == 0
+        assert client.sent == []
+        assert [t.item_id for t in state.history] == ["u1", "a1", "u2", "a2"]
+
+        await handle_conversation_item_retrieved(
+            {
+                "type": "conversation.item.retrieved",
+                "item": {
+                    "id": "u1",
+                    "role": "user",
+                    "content": [{"type": "input_text", "transcript": "hola"}],
+                },
+            },
+            client,
+            state,
+            summarizer,
+            policy,
+        )
+
+        assert summarizer.calls == 1
+        assert state.summary_count == 1
+        assert state.history[0].role == "system"
+        assert [t.item_id for t in state.history[1:]] == ["u2", "a2"]
+        assert [msg["type"] for msg in client.sent] == [
+            "conversation.item.create",
+            "conversation.item.delete",
+            "conversation.item.delete",
+        ]
+        delete_ids = [
+            msg.get("item_id") for msg in client.sent if msg["type"] == "conversation.item.delete"
+        ]
+        assert delete_ids == ["u1", "a1"]
+
+    asyncio.run(main())
+
+
 def test_openai_summarizer_returns_non_empty_string():
     async def main():
         summarizer = OpenAISummarizer()
@@ -61,7 +183,15 @@ def test_e2e_summary_added_and_prunes_history(monkeypatch):
                     ],
                     "usage": {"total_tokens": 5000},
                 },
-            }
+            },
+            {
+                "type": "conversation.item.retrieved",
+                "item": {
+                    "id": "u1",
+                    "role": "user",
+                    "content": [{"type": "input_text", "transcript": "hola"}],
+                },
+            },
         ]
 
         server = FakeRealtimeServer(events)
@@ -72,7 +202,7 @@ def test_e2e_summary_added_and_prunes_history(monkeypatch):
         monkeypatch.setitem(sys.modules, "websockets", fake_ws)
 
         state = ConversationState()
-        state.append(Turn(role="user", item_id="u1", text="hola"))
+        state.append(Turn(role="user", item_id="u1"))
         state.append(Turn(role="assistant", item_id="a1", text="hola"))
         state.append(Turn(role="user", item_id="u2", text="gracias"))
 
@@ -85,6 +215,10 @@ def test_e2e_summary_added_and_prunes_history(monkeypatch):
         dispatcher.on(
             "response.done",
             lambda ev: handle_response_done(ev, client, state, summarizer, policy),
+        )
+        dispatcher.on(
+            "conversation.item.retrieved",
+            lambda ev: handle_conversation_item_retrieved(ev, client, state, summarizer, policy),
         )
 
         task = asyncio.create_task(client.connect())


### PR DESCRIPTION
## Summary
- add a conversation.item.retrieved handler that backfills transcripts and retriggers summarization when pending turns complete
- guard summarize_and_prune against missing transcripts and recheck before pruning while wiring the handler into the app
- extend summarization coverage and provide a lightweight BaseSettings shim so tests run without pydantic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c83f2d9cec8330a7c0fdf0ded4985c