### PR TITLE
Implement OpenAI summarizer and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ voicebot run --provider azure --endpoint https://your-resource.openai.azure.com 
   --deployment realtime --api-version 2024-07-01-preview
 ```
 
+### Summarization settings
+
+Summaries are produced with the OpenAI Responses API using `SUMMARY_MODEL`
+(defaults to `gpt-4o-mini`). The following environment variables tune the
+behaviour:
+
+| Variable | Purpose |
+| --- | --- |
+| `SUMMARY_MODEL` | Model or Azure deployment used for summarisation. Set to `none`/`null`/`off` to disable (uses the `NullSummarizer`). |
+| `SUMMARY_TRIGGER_TOKENS` | Token window that triggers summarisation/pruning. |
+| `KEEP_LAST_TURNS` | Number of most recent turns kept verbatim after summarising. |
+| `LANGUAGE_POLICY` | `auto`, `force`, or `en` to influence the prompt language. |
+
+When `PROVIDER=openai`, set `OPENAI_API_KEY` (and optionally `OPENAI_BASE_URL`).
+For Azure, configure the `AZURE_OPENAI_*` variables and provide a deployment
+name via `SUMMARY_MODEL`.
+
 ## Development
 
 Create a virtual environment with Python 3.11 or newer and install the development
@@ -103,7 +120,7 @@ See the Architecture section below for module layout. The original tutorial scri
 ## Remaining Gaps (to address)
 
 1. **App orchestration**: `app.run` is a stub. It should wire `RealtimeClient`, `MicStreamer → append_audio`, `AudioPlayer`, handler registration, and graceful lifecycle.
-2. **Summarizer backend**: `OpenAISummarizer` is a stub; replace with a real OpenAI‑backed implementation that honors the language policy. Keep tests hermetic via mocking.
+2. **Summarizer resiliency**: add retries/backoff around the Responses API call and expose metrics/counters for failures.
 3. **Transcript backfill**: Implement `conversation.item.retrieved` handler to backfill missing transcripts; ensure summarization defers until backfill completes.
 4. **Latency timers wiring**: Wire EoS→first‑delta and first‑delta→playback timers at appropriate events (e.g., `response.created`/first `response.audio.delta`), and add tests.
 5. **Error handling**: Add explicit handlers for `response.error` and related failure paths with error taxonomy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "sounddevice>=0.4.6",
   "websockets>=11.0",
   "typer>=0.12",
+  "openai>=1.40.0",
 ]
 
 [project.scripts]

--- a/realtime_voicebot/app.py
+++ b/realtime_voicebot/app.py
@@ -27,14 +27,18 @@ async def run(settings: Settings | None = None) -> None:
     from .handlers.tools import ToolRegistry, clock_tool, handle_tool_call, http_tool
     from .redaction import Redactor
     from .state.conversation import ConversationState, SummaryPolicy
-    from .summarization.openai_impl import OpenAISummarizer
+    from .summarization.openai_impl import NullSummarizer, OpenAISummarizer
     from .transport.client import RealtimeClient, build_ws_url_headers
     from .transport.events import Dispatcher
 
     log = logging.getLogger(__name__)
 
     state = ConversationState(redact=Redactor(enabled=settings.redact_pii).redact)
-    summarizer = OpenAISummarizer()
+    summary_model = (settings.summary_model or "").strip()
+    if not summary_model or summary_model.lower() in {"none", "null", "off", "disabled"}:
+        summarizer = NullSummarizer()
+    else:
+        summarizer = OpenAISummarizer(settings=settings)
     policy = SummaryPolicy(
         threshold_tokens=settings.summary_trigger_tokens,
         keep_last_turns=settings.keep_last_turns,

--- a/realtime_voicebot/app.py
+++ b/realtime_voicebot/app.py
@@ -27,6 +27,7 @@ async def run(settings: Settings | None = None) -> None:
     from .handlers.tools import ToolRegistry, clock_tool, handle_tool_call, http_tool
     from .redaction import Redactor
     from .state.conversation import ConversationState, SummaryPolicy
+    from .summarization.base import Summarizer
     from .summarization.openai_impl import NullSummarizer, OpenAISummarizer
     from .transport.client import RealtimeClient, build_ws_url_headers
     from .transport.events import Dispatcher
@@ -35,6 +36,7 @@ async def run(settings: Settings | None = None) -> None:
 
     state = ConversationState(redact=Redactor(enabled=settings.redact_pii).redact)
     summary_model = (settings.summary_model or "").strip()
+    summarizer: Summarizer
     if not summary_model or summary_model.lower() in {"none", "null", "off", "disabled"}:
         summarizer = NullSummarizer()
     else:

--- a/realtime_voicebot/handlers/core.py
+++ b/realtime_voicebot/handlers/core.py
@@ -87,6 +87,8 @@ async def handle_response_done(
     state.record_usage(usage.get("total_tokens"))
 
     if policy.should_summarize(state):
+        if getattr(summarizer, "disabled", False):
+            return
         language = policy.determine_language(state.history)
         await state.summarize_and_prune(
             summarizer,
@@ -142,6 +144,8 @@ async def handle_conversation_item_retrieved(
         updated = True
 
     if policy.should_summarize(state):
+        if getattr(summarizer, "disabled", False):
+            return
         language = policy.determine_language(state.history)
         await state.summarize_and_prune(
             summarizer,

--- a/realtime_voicebot/summarization/openai_impl.py
+++ b/realtime_voicebot/summarization/openai_impl.py
@@ -139,12 +139,13 @@ class OpenAISummarizer(Summarizer):
 
             if not getattr(settings, "azure_openai_api_key", ""):
                 raise RuntimeError("AZURE_OPENAI_API_KEY is required for summarization")
-            if not getattr(settings, "azure_openai_endpoint", None):
+            azure_endpoint = settings.azure_openai_endpoint
+            if not azure_endpoint:
                 raise RuntimeError("AZURE_OPENAI_ENDPOINT is required for summarization")
             return AsyncAzureOpenAI(
                 api_key=settings.azure_openai_api_key,
                 api_version=settings.azure_openai_api_version,
-                azure_endpoint=settings.azure_openai_endpoint,
+                azure_endpoint=azure_endpoint,
             )
 
         from openai import AsyncOpenAI

--- a/realtime_voicebot/summarization/openai_impl.py
+++ b/realtime_voicebot/summarization/openai_impl.py
@@ -1,36 +1,48 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-from collections.abc import Iterable
+from typing import Any
 
+from ..config import Settings, get_settings
 from ..metrics import Timer
 from ..state.conversation import Turn
 from .base import Summarizer
 
+_LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "es": "Spanish",
+    "fr": "French",
+}
+
+
+class NullSummarizer(Summarizer):
+    """No-op summarizer used when summarization is disabled."""
+
+    disabled = True
+
+    async def summarize(self, turns: list[Turn], language: str | None = None) -> str:
+        return ""
+
 
 class OpenAISummarizer(Summarizer):
-    """OpenAI-backed summarizer (stub).
+    """Summarizer backed by the OpenAI Responses API."""
 
-    The implementation avoids a real network call to keep tests hermetic. It
-    still exposes the async interface so a real client can be wired in later
-    without changing callers.
-    """
-
-    def __init__(self) -> None:
-        # ``config`` depends on pydantic which may be missing in lightweight
-        # test environments. Import lazily and fall back to defaults.
-        try:  # pragma: no cover - configuration loading is trivial
-            from ..config import get_settings
-
-            self.settings = get_settings()
-        except Exception:  # pragma: no cover - fallback for missing deps
-            self.settings = type("_S", (), {"summary_model": "gpt-4o-mini"})()
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        settings: Settings | None = None,
+    ) -> None:
         self.log = logging.getLogger(__name__)
+        self.settings = settings or self._load_settings()
+        self._client = client or self._build_client(self.settings)
 
     async def summarize(self, turns: list[Turn], language: str | None = None) -> str:
         timer = Timer()
         timer.start()
+        language_code = (language or "en").lower()
+        transcript = self._format_transcript(turns)
+
         self.log.info(
             "summarization_start",
             extra={
@@ -40,14 +52,52 @@ class OpenAISummarizer(Summarizer):
                 "latency_ms": None,
                 "tokens_total": None,
                 "dropped_frames": None,
+                "language": language_code,
             },
         )
-        recent: Iterable[str] = (t.text or "" for t in turns[-3:])
-        await asyncio.sleep(0)
-        joined = " ".join(s for s in recent if s)
-        synopsis = joined if joined else "no content"
-        summary = f"Synopsis: {synopsis}. Facts: none."
-        timer.stop()
+
+        if not transcript.strip():
+            timer.stop()
+            self.log.info(
+                "summarization_end",
+                extra={
+                    "event_type": "summarization_end",
+                    "turn_id": None,
+                    "response_id": None,
+                    "latency_ms": timer.last_ms,
+                    "tokens_total": None,
+                    "dropped_frames": None,
+                    "language": language_code,
+                },
+            )
+            return "Synopsis: conversation context not yet available.\nFacts: none."
+
+        system_prompt = self._system_prompt(language_code)
+        payload = [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": system_prompt}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": transcript}],
+            },
+        ]
+
+        summary_text = ""
+        try:
+            response = await self._client.responses.create(
+                model=self.settings.summary_model,
+                input=payload,
+                temperature=0,
+            )
+            summary_text = self._extract_text(response).strip()
+        finally:
+            timer.stop()
+
+        if not summary_text:
+            summary_text = "Synopsis: conversation summary unavailable.\nFacts: none."
+
         self.log.info(
             "summarization_end",
             extra={
@@ -57,6 +107,131 @@ class OpenAISummarizer(Summarizer):
                 "latency_ms": timer.last_ms,
                 "tokens_total": None,
                 "dropped_frames": None,
+                "language": language_code,
             },
         )
-        return summary
+        return summary_text
+
+    @staticmethod
+    def _load_settings() -> Settings:
+        try:  # pragma: no cover - trivial configuration path
+            return get_settings()
+        except Exception:  # pragma: no cover - fallback when pydantic missing
+            return type(
+                "_FallbackSettings",
+                (),
+                {
+                    "summary_model": "gpt-4o-mini",
+                    "provider": "openai",
+                    "openai_api_key": "",
+                    "openai_base_url": None,
+                    "azure_openai_api_key": "",
+                    "azure_openai_endpoint": None,
+                    "azure_openai_api_version": "2024-07-01-preview",
+                    "azure_openai_deployment": "",
+                },
+            )()
+
+    def _build_client(self, settings: Settings) -> Any:
+        provider = getattr(settings, "provider", "openai")
+        if provider == "azure":
+            from openai import AsyncAzureOpenAI
+
+            if not getattr(settings, "azure_openai_api_key", ""):
+                raise RuntimeError("AZURE_OPENAI_API_KEY is required for summarization")
+            if not getattr(settings, "azure_openai_endpoint", None):
+                raise RuntimeError("AZURE_OPENAI_ENDPOINT is required for summarization")
+            return AsyncAzureOpenAI(
+                api_key=settings.azure_openai_api_key,
+                api_version=settings.azure_openai_api_version,
+                azure_endpoint=settings.azure_openai_endpoint,
+            )
+
+        from openai import AsyncOpenAI
+
+        api_key = getattr(settings, "openai_api_key", "")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY is required for summarization")
+
+        base_url = getattr(settings, "openai_base_url", None)
+        client_kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        return AsyncOpenAI(**client_kwargs)
+
+    def _system_prompt(self, language: str) -> str:
+        instruction = self._language_instruction(language)
+        return (
+            "You maintain a rolling summary of a voice assistant conversation. "
+            "Write a concise update that future assistant turns can rely on. "
+            "Always respond with exactly two lines using this template:\n"
+            "Synopsis: <one sentence overview>\n"
+            "Facts: <semicolon-separated enduring facts or 'none'>. "
+            "Do not invent details or include speaker markers. "
+            f"{instruction}"
+        )
+
+    def _language_instruction(self, language: str) -> str:
+        normalized = language.lower()
+        if normalized in {"", "en"}:
+            return "Respond in English."
+        name = _LANGUAGE_NAMES.get(normalized)
+        if name:
+            return f"Respond entirely in {name} ({normalized}) without mixing other languages."
+        return (
+            "Respond entirely in the language identified by the ISO code "
+            f"'{normalized}' without mixing other languages."
+        )
+
+    def _format_transcript(self, turns: list[Turn]) -> str:
+        role_labels = {"user": "User", "assistant": "Assistant", "system": "System"}
+        lines: list[str] = []
+        for turn in turns:
+            if not turn.text:
+                continue
+            label = role_labels.get(turn.role, turn.role)
+            lines.append(f"{label}: {turn.text.strip()}")
+        return "\n".join(lines)
+
+    def _extract_text(self, response: Any) -> str:
+        text = getattr(response, "output_text", None)
+        if isinstance(text, str) and text.strip():
+            return text
+
+        outputs = getattr(response, "output", None)
+        if outputs is None and isinstance(response, dict):
+            outputs = response.get("output")
+
+        collected: list[str] = []
+        for item in outputs or []:
+            content = getattr(item, "content", None)
+            if content is None and isinstance(item, dict):
+                content = item.get("content")
+            for block in content or []:
+                block_text = getattr(block, "text", None)
+                if block_text is None and isinstance(block, dict):
+                    block_text = block.get("text")
+                if isinstance(block_text, str) and block_text.strip():
+                    collected.append(block_text.strip())
+
+        if collected:
+            return "\n".join(collected)
+
+        # Fallback for chat-completions style responses if returned.
+        choices = getattr(response, "choices", None)
+        if choices is None and isinstance(response, dict):
+            choices = response.get("choices")
+        if choices:
+            for choice in choices:
+                message = getattr(choice, "message", None)
+                if message is None and isinstance(choice, dict):
+                    message = choice.get("message")
+                if not message:
+                    continue
+                content = getattr(message, "content", None)
+                if content is None and isinstance(message, dict):
+                    content = message.get("content")
+                if isinstance(content, str) and content.strip():
+                    return content.strip()
+
+        return ""


### PR DESCRIPTION
## Summary
- replace the summarizer stub with an OpenAI Responses client and add a NullSummarizer fallback
- skip summarisation when disabled, support dependency injection in tests, and add the OpenAI SDK dependency
- document summarisation environment variables and disabling behaviour in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c84f82097c83308b480e556e3a114c